### PR TITLE
Refactor SecurityResourceInterface::publicKeyCertificates and BatchResourceInterface::openAndSend to return Response contracts instead of implementations

### DIFF
--- a/src/Contracts/Requests/Security/PublicKeyCertificates/PublicKeyCertificatesResponseInterface.php
+++ b/src/Contracts/Requests/Security/PublicKeyCertificates/PublicKeyCertificatesResponseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N1ebieski\KSEFClient\Contracts\Requests\Security\PublicKeyCertificates;
+
+use N1ebieski\KSEFClient\Contracts\HttpClient\ResponseInterface;
+use N1ebieski\KSEFClient\ValueObjects\Requests\Security\PublicKeyCertificates\PublicKeyCertificateUsage;
+
+interface PublicKeyCertificatesResponseInterface extends ResponseInterface
+{
+    public function getFirstByPublicKeyCertificateUsage(PublicKeyCertificateUsage $type): ?string;
+}

--- a/src/Contracts/Requests/Sessions/Batch/OpenAndSend/OpenAndSendResponseInterface.php
+++ b/src/Contracts/Requests/Sessions/Batch/OpenAndSend/OpenAndSendResponseInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace N1ebieski\KSEFClient\Contracts\Requests\Sessions\Batch\OpenAndSend;
+
+use N1ebieski\KSEFClient\Contracts\HttpClient\ResponseInterface;
+use Psr\Http\Message\ResponseInterface as BaseResponseInterface;
+
+/**
+ * @property-read BaseResponseInterface $baseOpenResponse
+ * @property-read array<int, ResponseInterface|null> $partUploadResponses
+ */
+interface OpenAndSendResponseInterface extends ResponseInterface
+{
+}

--- a/src/Contracts/Resources/Security/SecurityResourceInterface.php
+++ b/src/Contracts/Resources/Security/SecurityResourceInterface.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace N1ebieski\KSEFClient\Contracts\Resources\Security;
 
-use N1ebieski\KSEFClient\Requests\Security\PublicKeyCertificates\PublicKeyCertificatesResponse;
+use N1ebieski\KSEFClient\Contracts\Requests\Security\PublicKeyCertificates\PublicKeyCertificatesResponseInterface;
 
 interface SecurityResourceInterface
 {
-    public function publicKeyCertificates(): PublicKeyCertificatesResponse;
+    public function publicKeyCertificates(): PublicKeyCertificatesResponseInterface;
 }

--- a/src/Contracts/Resources/Sessions/Batch/BatchResourceInterface.php
+++ b/src/Contracts/Resources/Sessions/Batch/BatchResourceInterface.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace N1ebieski\KSEFClient\Contracts\Resources\Sessions\Batch;
 
 use N1ebieski\KSEFClient\Contracts\HttpClient\ResponseInterface;
+use N1ebieski\KSEFClient\Contracts\Requests\Sessions\Batch\OpenAndSend\OpenAndSendResponseInterface;
 use N1ebieski\KSEFClient\Requests\Sessions\Batch\Close\CloseRequest;
 use N1ebieski\KSEFClient\Requests\Sessions\Batch\OpenAndSend\OpenAndSendRequest;
-use N1ebieski\KSEFClient\Requests\Sessions\Batch\OpenAndSend\OpenAndSendResponse;
 use N1ebieski\KSEFClient\Requests\Sessions\Batch\OpenAndSend\OpenAndSendXmlRequest;
 use N1ebieski\KSEFClient\Requests\Sessions\Batch\OpenAndSend\OpenAndSendZipRequest;
 
@@ -16,7 +16,7 @@ interface BatchResourceInterface
     /**
      * @param OpenAndSendRequest|OpenAndSendXmlRequest|OpenAndSendZipRequest|array<string, mixed> $request
      */
-    public function openAndSend(OpenAndSendRequest | OpenAndSendXmlRequest | OpenAndSendZipRequest | array $request): OpenAndSendResponse;
+    public function openAndSend(OpenAndSendRequest | OpenAndSendXmlRequest | OpenAndSendZipRequest | array $request): OpenAndSendResponseInterface;
 
     /**
      * @param CloseRequest|array<string, mixed> $request

--- a/src/Requests/Security/PublicKeyCertificates/PublicKeyCertificatesResponse.php
+++ b/src/Requests/Security/PublicKeyCertificates/PublicKeyCertificatesResponse.php
@@ -7,11 +7,12 @@ namespace N1ebieski\KSEFClient\Requests\Security\PublicKeyCertificates;
 use DateTimeImmutable;
 use DateTimeZone;
 use N1ebieski\KSEFClient\Contracts\HttpClient\ResponseInterface;
+use N1ebieski\KSEFClient\Contracts\Requests\Security\PublicKeyCertificates\PublicKeyCertificatesResponseInterface;
 use N1ebieski\KSEFClient\ValueObjects\Requests\Security\PublicKeyCertificates\PublicKeyCertificateUsage;
 use N1ebieski\KSEFClient\ValueObjects\Support\KeyType;
 use Psr\Http\Message\ResponseInterface as BaseResponseInterface;
 
-final class PublicKeyCertificatesResponse implements ResponseInterface
+final class PublicKeyCertificatesResponse implements PublicKeyCertificatesResponseInterface
 {
     public readonly BaseResponseInterface $baseResponse;
 

--- a/src/Requests/Sessions/Batch/OpenAndSend/OpenAndSendResponse.php
+++ b/src/Requests/Sessions/Batch/OpenAndSend/OpenAndSendResponse.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace N1ebieski\KSEFClient\Requests\Sessions\Batch\OpenAndSend;
 
 use N1ebieski\KSEFClient\Contracts\HttpClient\ResponseInterface;
+use N1ebieski\KSEFClient\Contracts\Requests\Sessions\Batch\OpenAndSend\OpenAndSendResponseInterface;
 use N1ebieski\KSEFClient\ValueObjects\Support\KeyType;
 use Psr\Http\Message\ResponseInterface as BaseResponseInterface;
 
-final class OpenAndSendResponse implements ResponseInterface
+final class OpenAndSendResponse implements OpenAndSendResponseInterface
 {
     public readonly BaseResponseInterface $baseOpenResponse;
 


### PR DESCRIPTION
Fixes #113