### PR TITLE
update condition in generate QR codes to check KSeF number value

### DIFF
--- a/src/Actions/GenerateQRCodes/GenerateQRCodesHandler.php
+++ b/src/Actions/GenerateQRCodes/GenerateQRCodesHandler.php
@@ -56,7 +56,7 @@ final class GenerateQRCodesHandler extends AbstractHandler
         $code2 = null;
 
         if (
-            ! $action->ksefNumber instanceof KsefNumber
+            ! ($action->ksefNumber instanceof KsefNumber)
             && $action->certificate instanceof Certificate
             && $action->certificateSerialNumber instanceof CertificateSerialNumber
             && $action->contextIdentifierGroup instanceof ContextIdentifierGroup


### PR DESCRIPTION
W dokumentacji (https://ksef.podatki.gov.pl/informacje-ogolne-ksef-20/kody-weryfikujace-qr/) opisane jest w jakich przypadkach i kiedy stosuje się kody QR, w skrócie:

- 1 kod QR jeśli jest nadany numer KSeF
- 2 kody QR gdy numeru KSeF nie ma

W aktualnej postaci trzeba ustawiać na `null` lub odpowiednie typy dla 3 pól (certyfikat + hasło + kontekst idnetyfikatora) w zależności od zawartości w `KSeFNumber`.
Wydaje mi się, że ta dość prosta poprawka nikomu nie powinna zaszkodzić, a uspójnia logikę KSeF'ową w kwestii kodów QR.