### PR TITLE
Refactor cache key retrieval in PublicKeyCertificatesHandler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "n1ebieski/ksef-php-client",
     "description": "PHP API client that allows you to interact with the API Krajowego Systemu e-Faktur",
-    "version": "0.29.0",
+    "version": "0.29.1",
     "license": "MIT",
     "authors": [
         {

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -318,6 +318,7 @@ final class ClientBuilder
     public function build(): ClientResource
     {
         $config = new Config(
+            mode: $this->mode,
             baseUri: new BaseUri($this->apiUrl->value),
             latarniaBaseUri: new BaseUri($this->latarniaApiUrl->value),
             asyncMaxConcurrency: $this->asyncMaxConcurrency,

--- a/src/Contracts/ConfigInterface.php
+++ b/src/Contracts/ConfigInterface.php
@@ -19,5 +19,5 @@ interface ConfigInterface
     /**
      * @var string
      */
-    public const PUBLIC_KEY_CERTIFICATES_CACHE_KEY = 'ksef_public_key_certificates';
+    public const PUBLIC_KEY_CERTIFICATES_CACHE_KEY = '%s_ksef_public_key_certificates';
 }

--- a/src/DTOs/Config.php
+++ b/src/DTOs/Config.php
@@ -9,12 +9,14 @@ use N1ebieski\KSEFClient\Support\AbstractDTO;
 use N1ebieski\KSEFClient\ValueObjects\AccessToken;
 use N1ebieski\KSEFClient\ValueObjects\EncryptionKey;
 use N1ebieski\KSEFClient\ValueObjects\HttpClient\BaseUri;
+use N1ebieski\KSEFClient\ValueObjects\Mode;
 use N1ebieski\KSEFClient\ValueObjects\RefreshToken;
 use N1ebieski\KSEFClient\ValueObjects\Requests\Sessions\EncryptedKey;
 
 final class Config extends AbstractDTO implements ConfigInterface
 {
     public function __construct(
+        public readonly Mode $mode,
         public readonly BaseUri $baseUri,
         public readonly BaseUri $latarniaBaseUri,
         public readonly int $asyncMaxConcurrency = 8,

--- a/src/Requests/Security/PublicKeyCertificates/PublicKeyCertificatesHandler.php
+++ b/src/Requests/Security/PublicKeyCertificates/PublicKeyCertificatesHandler.php
@@ -22,11 +22,6 @@ final class PublicKeyCertificatesHandler extends AbstractHandler
     ) {
     }
 
-    private function getCacheKeyForMode(): string
-    {
-        return ConfigInterface::PUBLIC_KEY_CERTIFICATES_CACHE_KEY . '_' . $this->config->baseUri->value;
-    }
-
     public function handle(): PublicKeyCertificatesResponse
     {
         if ( ! $this->cache instanceof CacheInterface) {
@@ -48,6 +43,11 @@ final class PublicKeyCertificatesHandler extends AbstractHandler
         );
 
         return $response;
+    }
+
+    private function getCacheKeyForMode(): string
+    {
+        return sprintf(ConfigInterface::PUBLIC_KEY_CERTIFICATES_CACHE_KEY, $this->config->mode->value);
     }
 
     private function getPublicKeyCertificatesResponse(): PublicKeyCertificatesResponse

--- a/tests/Unit/AbstractTestCase.php
+++ b/tests/Unit/AbstractTestCase.php
@@ -67,6 +67,7 @@ abstract class AbstractTestCase extends TestCase
         return new ClientResource(
             client: $httpClientStub,
             config: new Config(
+                mode: Mode::Test,
                 baseUri: new BaseUri(Mode::Test->getApiUrl()->value),
                 latarniaBaseUri: new BaseUri(Mode::Test->getLatarniaApiUrl()->value),
                 encryptionKey: EncryptionKeyFactory::makeRandom()

--- a/tests/Unit/Requests/Security/PublicKeyCertificates/PublicKeyCertificatesHandlerTest.php
+++ b/tests/Unit/Requests/Security/PublicKeyCertificates/PublicKeyCertificatesHandlerTest.php
@@ -9,6 +9,7 @@ use N1ebieski\KSEFClient\HttpClient\Response;
 use N1ebieski\KSEFClient\Requests\Security\PublicKeyCertificates\PublicKeyCertificatesResponse;
 use N1ebieski\KSEFClient\Testing\Fixtures\Requests\Security\PublicKeyCertificates\PublicKeyCertificatesResponseFixture;
 use N1ebieski\KSEFClient\Tests\Unit\AbstractTestCase;
+use N1ebieski\KSEFClient\ValueObjects\Mode;
 use Psr\SimpleCache\CacheInterface;
 
 /** @var AbstractTestCase $this */
@@ -74,7 +75,7 @@ test('fetches from source and saves to cache when cache has no value', function 
     $cacheStub->shouldReceive('set')
         ->once()
         ->withArgs(fn (string $key, mixed $value, int $ttl): bool =>
-            $key === ConfigInterface::PUBLIC_KEY_CERTIFICATES_CACHE_KEY
+            $key === sprintf(ConfigInterface::PUBLIC_KEY_CERTIFICATES_CACHE_KEY, Mode::Test->value)
                 && $value instanceof PublicKeyCertificatesResponse
                 && $ttl === 43200)
         ->andReturn(true);

--- a/tests/Unit/Requests/Sessions/Batch/OpenAndSend/OpenAndSendHandlerTest.php
+++ b/tests/Unit/Requests/Sessions/Batch/OpenAndSend/OpenAndSendHandlerTest.php
@@ -61,6 +61,7 @@ test('valid response', function (OpenAndSendRequestFixture $requestFixture, Open
     $clientStub = (new ClientResource(
         client: $httpClientStub,
         config: new Config(
+            mode: Mode::Test,
             baseUri: new BaseUri(Mode::Test->getApiUrl()->value),
             latarniaBaseUri: new BaseUri(Mode::Test->getLatarniaApiUrl()->value),
             encryptionKey: EncryptionKeyFactory::makeRandom()


### PR DESCRIPTION
Hi,

I propose a small improvement that I had a dream about last night...

The current caching mechanism uses a static key, which is prone to collisions in "multi-mode" setups where different KSeF environments (e.g., Test and Production) share the same cache backend. To prevent this accidental overlap of essences, I’ve updated the handler to include the environment’s base URI in the cache key.

Thoughts?