### PR TITLE
Fix DateTimeImmutable normalization in Faktura/FakturaRR

### DIFF
--- a/_ide_helper.php
+++ b/_ide_helper.php
@@ -10,6 +10,7 @@ namespace Pest {
     /**
      * @method void toBeFixture(array $data, ?object $object = null)
      * @method void toBeExceptionFixture(array $data)
+     * @method void toBeArrayWithoutObjectsRecursively()
      */
     class Expectation extends BaseExpectation
     {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "ksef php",
         "ksef php client"
     ],
-    "version": "1.2.0",
+    "version": "1.2.1",
     "license": "MIT",
     "authors": [
         {

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -22,6 +22,7 @@ parameters:
 		- '#^Call to an undefined method Pest\\Expectation<([a-zA-Z0-9\\]+)\|null>::toBeFixture\(\).$#'
 		- '#^Call to an undefined method Pest\\Expectation<array<string, mixed>\|object\|null>::toBeFixture\(\).$#'
 		- '#^Call to an undefined method Pest\\Expectation<\(Closure\)\|null>::toBeExceptionFixture\(\).$#'
+		- '#^Call to an undefined method Pest\\Expectation<array<int\|string, mixed>\|null>::toBeArrayWithoutObjectsRecursively\(\)\.$#'
 		- '#^Call to an undefined method Pest\\PendingCalls\\TestCall\|Pest\\Support\\HigherOrderTapProxy::throws\(\).$#'
 		- '#^Cannot call method (withHash|withMGFHash|withSaltLength|sign|encrypt)\(\) on mixed.$#'
 		-
@@ -35,4 +36,4 @@ parameters:
 			path: tests/*
 		-
 			message: '#^Cannot call method (andReturn(Self)?|withArgs)\(\) on mixed\.$#'
-			path: tests/*                        
+			path: tests/*

--- a/src/Contracts/WithInterface.php
+++ b/src/Contracts/WithInterface.php
@@ -9,5 +9,5 @@ interface WithInterface
     /**
      * @param array<string, mixed> $data
      */
-    public function with(array $data): self;
+    public function with(array $data): static;
 }

--- a/src/ValueObjects/Requests/Sessions/DataGodzRozpTransportu.php
+++ b/src/ValueObjects/Requests/Sessions/DataGodzRozpTransportu.php
@@ -6,6 +6,7 @@ namespace N1ebieski\KSEFClient\ValueObjects\Requests\Sessions;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use N1ebieski\KSEFClient\Contracts\OriginalInterface;
 use DateTimeZone;
 use N1ebieski\KSEFClient\Contracts\ValueAwareInterface;
 use N1ebieski\KSEFClient\Support\AbstractValueObject;
@@ -15,7 +16,7 @@ use N1ebieski\KSEFClient\Validator\Rules\Date\TimezoneRule;
 use N1ebieski\KSEFClient\Validator\Validator;
 use Stringable;
 
-final class DataGodzRozpTransportu extends AbstractValueObject implements ValueAwareInterface, Stringable
+final class DataGodzRozpTransportu extends AbstractValueObject implements ValueAwareInterface, Stringable, OriginalInterface
 {
     public readonly DateTimeInterface $value;
 
@@ -37,6 +38,11 @@ final class DataGodzRozpTransportu extends AbstractValueObject implements ValueA
     public function __toString(): string
     {
         return $this->value->format('Y-m-d\TH:i:s\Z');
+    }
+
+    public function toOriginal(): string
+    {
+        return (string) $this;
     }
 
     public static function from(string $value): self

--- a/src/ValueObjects/Requests/Sessions/DataGodzZakTransportu.php
+++ b/src/ValueObjects/Requests/Sessions/DataGodzZakTransportu.php
@@ -6,6 +6,7 @@ namespace N1ebieski\KSEFClient\ValueObjects\Requests\Sessions;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use N1ebieski\KSEFClient\Contracts\OriginalInterface;
 use DateTimeZone;
 use N1ebieski\KSEFClient\Contracts\ValueAwareInterface;
 use N1ebieski\KSEFClient\Support\AbstractValueObject;
@@ -15,7 +16,7 @@ use N1ebieski\KSEFClient\Validator\Rules\Date\TimezoneRule;
 use N1ebieski\KSEFClient\Validator\Validator;
 use Stringable;
 
-final class DataGodzZakTransportu extends AbstractValueObject implements ValueAwareInterface, Stringable
+final class DataGodzZakTransportu extends AbstractValueObject implements ValueAwareInterface, Stringable, OriginalInterface
 {
     public readonly DateTimeInterface $value;
 
@@ -37,6 +38,11 @@ final class DataGodzZakTransportu extends AbstractValueObject implements ValueAw
     public function __toString(): string
     {
         return $this->value->format('Y-m-d\TH:i:s\Z');
+    }
+
+    public function toOriginal(): string
+    {
+        return (string) $this;
     }
 
     public static function from(string $value): self

--- a/src/ValueObjects/Requests/Sessions/DataUmowy.php
+++ b/src/ValueObjects/Requests/Sessions/DataUmowy.php
@@ -6,6 +6,7 @@ namespace N1ebieski\KSEFClient\ValueObjects\Requests\Sessions;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use N1ebieski\KSEFClient\Contracts\OriginalInterface;
 use N1ebieski\KSEFClient\Contracts\ValueAwareInterface;
 use N1ebieski\KSEFClient\Support\AbstractValueObject;
 use N1ebieski\KSEFClient\Validator\Rules\Date\AfterRule;
@@ -13,7 +14,7 @@ use N1ebieski\KSEFClient\Validator\Rules\Date\BeforeRule;
 use N1ebieski\KSEFClient\Validator\Validator;
 use Stringable;
 
-final class DataUmowy extends AbstractValueObject implements ValueAwareInterface, Stringable
+final class DataUmowy extends AbstractValueObject implements ValueAwareInterface, Stringable, OriginalInterface
 {
     public readonly DateTimeInterface $value;
 
@@ -34,6 +35,11 @@ final class DataUmowy extends AbstractValueObject implements ValueAwareInterface
     public function __toString(): string
     {
         return $this->value->format('Y-m-d');
+    }
+
+    public function toOriginal(): string
+    {
+        return (string) $this;
     }
 
     public static function from(string $value): self

--- a/src/ValueObjects/Requests/Sessions/DataWystFaKorygowanej.php
+++ b/src/ValueObjects/Requests/Sessions/DataWystFaKorygowanej.php
@@ -6,6 +6,7 @@ namespace N1ebieski\KSEFClient\ValueObjects\Requests\Sessions;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use N1ebieski\KSEFClient\Contracts\OriginalInterface;
 use N1ebieski\KSEFClient\Contracts\ValueAwareInterface;
 use N1ebieski\KSEFClient\Support\AbstractValueObject;
 use N1ebieski\KSEFClient\Validator\Rules\Date\AfterRule;
@@ -13,7 +14,7 @@ use N1ebieski\KSEFClient\Validator\Rules\Date\BeforeRule;
 use N1ebieski\KSEFClient\Validator\Validator;
 use Stringable;
 
-final class DataWystFaKorygowanej extends AbstractValueObject implements ValueAwareInterface, Stringable
+final class DataWystFaKorygowanej extends AbstractValueObject implements ValueAwareInterface, Stringable, OriginalInterface
 {
     public readonly DateTimeInterface $value;
 
@@ -34,6 +35,11 @@ final class DataWystFaKorygowanej extends AbstractValueObject implements ValueAw
     public function __toString(): string
     {
         return $this->value->format('Y-m-d');
+    }
+
+    public function toOriginal(): string
+    {
+        return (string) $this;
     }
 
     public static function from(string $value): self

--- a/src/ValueObjects/Requests/Sessions/DataWytworzeniaFa.php
+++ b/src/ValueObjects/Requests/Sessions/DataWytworzeniaFa.php
@@ -7,13 +7,14 @@ namespace N1ebieski\KSEFClient\ValueObjects\Requests\Sessions;
 use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
+use N1ebieski\KSEFClient\Contracts\OriginalInterface;
 use N1ebieski\KSEFClient\Contracts\ValueAwareInterface;
 use N1ebieski\KSEFClient\Support\AbstractValueObject;
 use N1ebieski\KSEFClient\Validator\Rules\Date\TimezoneRule;
 use N1ebieski\KSEFClient\Validator\Validator;
 use Stringable;
 
-final class DataWytworzeniaFa extends AbstractValueObject implements ValueAwareInterface, Stringable
+final class DataWytworzeniaFa extends AbstractValueObject implements ValueAwareInterface, Stringable, OriginalInterface
 {
     public readonly DateTimeInterface $value;
 
@@ -33,6 +34,11 @@ final class DataWytworzeniaFa extends AbstractValueObject implements ValueAwareI
     public function __toString(): string
     {
         return $this->value->format('Y-m-d\TH:i:s\Z');
+    }
+
+    public function toOriginal(): string
+    {
+        return (string) $this;
     }
 
     public static function from(string $value): self

--- a/src/ValueObjects/Requests/Sessions/DataZamowienia.php
+++ b/src/ValueObjects/Requests/Sessions/DataZamowienia.php
@@ -6,6 +6,7 @@ namespace N1ebieski\KSEFClient\ValueObjects\Requests\Sessions;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use N1ebieski\KSEFClient\Contracts\OriginalInterface;
 use N1ebieski\KSEFClient\Contracts\ValueAwareInterface;
 use N1ebieski\KSEFClient\Support\AbstractValueObject;
 use N1ebieski\KSEFClient\Validator\Rules\Date\AfterRule;
@@ -13,7 +14,7 @@ use N1ebieski\KSEFClient\Validator\Rules\Date\BeforeRule;
 use N1ebieski\KSEFClient\Validator\Validator;
 use Stringable;
 
-final class DataZamowienia extends AbstractValueObject implements ValueAwareInterface, Stringable
+final class DataZamowienia extends AbstractValueObject implements ValueAwareInterface, Stringable, OriginalInterface
 {
     public readonly DateTimeInterface $value;
 
@@ -34,6 +35,11 @@ final class DataZamowienia extends AbstractValueObject implements ValueAwareInte
     public function __toString(): string
     {
         return $this->value->format('Y-m-d');
+    }
+
+    public function toOriginal(): string
+    {
+        return (string) $this;
     }
 
     public static function from(string $value): self

--- a/src/ValueObjects/Requests/Sessions/DataZaplaty.php
+++ b/src/ValueObjects/Requests/Sessions/DataZaplaty.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace N1ebieski\KSEFClient\ValueObjects\Requests\Sessions;
 
 use DateTimeInterface;
+use N1ebieski\KSEFClient\Contracts\OriginalInterface;
 use DateTimeImmutable;
 use N1ebieski\KSEFClient\Contracts\ValueAwareInterface;
 use N1ebieski\KSEFClient\Support\AbstractValueObject;
@@ -13,7 +14,7 @@ use N1ebieski\KSEFClient\Validator\Rules\Date\BeforeRule;
 use N1ebieski\KSEFClient\Validator\Validator;
 use Stringable;
 
-final class DataZaplaty extends AbstractValueObject implements ValueAwareInterface, Stringable
+final class DataZaplaty extends AbstractValueObject implements ValueAwareInterface, Stringable, OriginalInterface
 {
     public readonly DateTimeInterface $value;
 
@@ -34,6 +35,11 @@ final class DataZaplaty extends AbstractValueObject implements ValueAwareInterfa
     public function __toString(): string
     {
         return $this->value->format('Y-m-d');
+    }
+
+    public function toOriginal(): string
+    {
+        return (string) $this;
     }
 
     public static function from(string $value): self

--- a/src/ValueObjects/Requests/Sessions/DataZaplatyCzesciowej.php
+++ b/src/ValueObjects/Requests/Sessions/DataZaplatyCzesciowej.php
@@ -6,6 +6,7 @@ namespace N1ebieski\KSEFClient\ValueObjects\Requests\Sessions;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use N1ebieski\KSEFClient\Contracts\OriginalInterface;
 use N1ebieski\KSEFClient\Contracts\ValueAwareInterface;
 use N1ebieski\KSEFClient\Support\AbstractValueObject;
 use N1ebieski\KSEFClient\Validator\Rules\Date\AfterRule;
@@ -13,7 +14,7 @@ use N1ebieski\KSEFClient\Validator\Rules\Date\BeforeRule;
 use N1ebieski\KSEFClient\Validator\Validator;
 use Stringable;
 
-final class DataZaplatyCzesciowej extends AbstractValueObject implements ValueAwareInterface, Stringable
+final class DataZaplatyCzesciowej extends AbstractValueObject implements ValueAwareInterface, Stringable, OriginalInterface
 {
     public readonly DateTimeInterface $value;
 
@@ -34,6 +35,11 @@ final class DataZaplatyCzesciowej extends AbstractValueObject implements ValueAw
     public function __toString(): string
     {
         return $this->value->format('Y-m-d');
+    }
+
+    public function toOriginal(): string
+    {
+        return (string) $this;
     }
 
     public static function from(string $value): self

--- a/src/ValueObjects/Requests/Sessions/FakturaRR/DataDokumentu.php
+++ b/src/ValueObjects/Requests/Sessions/FakturaRR/DataDokumentu.php
@@ -6,6 +6,7 @@ namespace N1ebieski\KSEFClient\ValueObjects\Requests\Sessions\FakturaRR;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use N1ebieski\KSEFClient\Contracts\OriginalInterface;
 use N1ebieski\KSEFClient\Contracts\ValueAwareInterface;
 use N1ebieski\KSEFClient\Support\AbstractValueObject;
 use N1ebieski\KSEFClient\Validator\Rules\Date\AfterRule;
@@ -13,7 +14,7 @@ use N1ebieski\KSEFClient\Validator\Rules\Date\BeforeRule;
 use N1ebieski\KSEFClient\Validator\Validator;
 use Stringable;
 
-final class DataDokumentu extends AbstractValueObject implements ValueAwareInterface, Stringable
+final class DataDokumentu extends AbstractValueObject implements ValueAwareInterface, Stringable, OriginalInterface
 {
     public readonly DateTimeInterface $value;
 
@@ -34,6 +35,11 @@ final class DataDokumentu extends AbstractValueObject implements ValueAwareInter
     public function __toString(): string
     {
         return $this->value->format('Y-m-d');
+    }
+
+    public function toOriginal(): string
+    {
+        return (string) $this;
     }
 
     public static function from(string $value): self

--- a/src/ValueObjects/Requests/Sessions/FakturaRR/P_4A.php
+++ b/src/ValueObjects/Requests/Sessions/FakturaRR/P_4A.php
@@ -6,6 +6,7 @@ namespace N1ebieski\KSEFClient\ValueObjects\Requests\Sessions\FakturaRR;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use N1ebieski\KSEFClient\Contracts\OriginalInterface;
 use N1ebieski\KSEFClient\Contracts\ValueAwareInterface;
 use N1ebieski\KSEFClient\Support\AbstractValueObject;
 use N1ebieski\KSEFClient\Validator\Rules\Date\AfterRule;
@@ -13,7 +14,7 @@ use N1ebieski\KSEFClient\Validator\Rules\Date\BeforeRule;
 use N1ebieski\KSEFClient\Validator\Validator;
 use Stringable;
 
-final class P_4A extends AbstractValueObject implements ValueAwareInterface, Stringable
+final class P_4A extends AbstractValueObject implements ValueAwareInterface, Stringable, OriginalInterface
 {
     public readonly DateTimeInterface $value;
 
@@ -34,6 +35,11 @@ final class P_4A extends AbstractValueObject implements ValueAwareInterface, Str
     public function __toString(): string
     {
         return $this->value->format('Y-m-d');
+    }
+
+    public function toOriginal(): string
+    {
+        return (string) $this;
     }
 
     public static function from(string $value): self

--- a/src/ValueObjects/Requests/Sessions/FakturaRR/P_4AA.php
+++ b/src/ValueObjects/Requests/Sessions/FakturaRR/P_4AA.php
@@ -6,6 +6,7 @@ namespace N1ebieski\KSEFClient\ValueObjects\Requests\Sessions\FakturaRR;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use N1ebieski\KSEFClient\Contracts\OriginalInterface;
 use N1ebieski\KSEFClient\Contracts\ValueAwareInterface;
 use N1ebieski\KSEFClient\Support\AbstractValueObject;
 use N1ebieski\KSEFClient\Validator\Rules\Date\AfterRule;
@@ -13,7 +14,7 @@ use N1ebieski\KSEFClient\Validator\Rules\Date\BeforeRule;
 use N1ebieski\KSEFClient\Validator\Validator;
 use Stringable;
 
-final class P_4AA extends AbstractValueObject implements ValueAwareInterface, Stringable
+final class P_4AA extends AbstractValueObject implements ValueAwareInterface, Stringable, OriginalInterface
 {
     public readonly DateTimeInterface $value;
 
@@ -34,6 +35,11 @@ final class P_4AA extends AbstractValueObject implements ValueAwareInterface, St
     public function __toString(): string
     {
         return $this->value->format('Y-m-d');
+    }
+
+    public function toOriginal(): string
+    {
+        return (string) $this;
     }
 
     public static function from(string $value): self

--- a/src/ValueObjects/Requests/Sessions/FakturaRR/P_4B.php
+++ b/src/ValueObjects/Requests/Sessions/FakturaRR/P_4B.php
@@ -6,6 +6,7 @@ namespace N1ebieski\KSEFClient\ValueObjects\Requests\Sessions\FakturaRR;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use N1ebieski\KSEFClient\Contracts\OriginalInterface;
 use N1ebieski\KSEFClient\Contracts\ValueAwareInterface;
 use N1ebieski\KSEFClient\Support\AbstractValueObject;
 use N1ebieski\KSEFClient\Validator\Rules\Date\AfterRule;
@@ -13,7 +14,7 @@ use N1ebieski\KSEFClient\Validator\Rules\Date\BeforeRule;
 use N1ebieski\KSEFClient\Validator\Validator;
 use Stringable;
 
-final class P_4B extends AbstractValueObject implements ValueAwareInterface, Stringable
+final class P_4B extends AbstractValueObject implements ValueAwareInterface, Stringable, OriginalInterface
 {
     public readonly DateTimeInterface $value;
 
@@ -34,6 +35,11 @@ final class P_4B extends AbstractValueObject implements ValueAwareInterface, Str
     public function __toString(): string
     {
         return $this->value->format('Y-m-d');
+    }
+
+    public function toOriginal(): string
+    {
+        return (string) $this;
     }
 
     public static function from(string $value): self

--- a/src/ValueObjects/Requests/Sessions/P_1.php
+++ b/src/ValueObjects/Requests/Sessions/P_1.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace N1ebieski\KSEFClient\ValueObjects\Requests\Sessions;
 
 use DateTimeInterface;
+use N1ebieski\KSEFClient\Contracts\OriginalInterface;
 use DateTimeImmutable;
 use N1ebieski\KSEFClient\Contracts\ValueAwareInterface;
 use N1ebieski\KSEFClient\Support\AbstractValueObject;
 use Stringable;
 
-final class P_1 extends AbstractValueObject implements ValueAwareInterface, Stringable
+final class P_1 extends AbstractValueObject implements ValueAwareInterface, Stringable, OriginalInterface
 {
     public readonly DateTimeInterface $value;
 
@@ -26,6 +27,11 @@ final class P_1 extends AbstractValueObject implements ValueAwareInterface, Stri
     public function __toString(): string
     {
         return $this->value->format('Y-m-d');
+    }
+
+    public function toOriginal(): string
+    {
+        return (string) $this;
     }
 
     public static function from(string $value): self

--- a/src/ValueObjects/Requests/Sessions/P_22A.php
+++ b/src/ValueObjects/Requests/Sessions/P_22A.php
@@ -6,6 +6,7 @@ namespace N1ebieski\KSEFClient\ValueObjects\Requests\Sessions;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use N1ebieski\KSEFClient\Contracts\OriginalInterface;
 use N1ebieski\KSEFClient\Contracts\ValueAwareInterface;
 use N1ebieski\KSEFClient\Support\AbstractValueObject;
 use N1ebieski\KSEFClient\Validator\Rules\Date\AfterRule;
@@ -13,7 +14,7 @@ use N1ebieski\KSEFClient\Validator\Rules\Date\BeforeRule;
 use N1ebieski\KSEFClient\Validator\Validator;
 use Stringable;
 
-final class P_22A extends AbstractValueObject implements ValueAwareInterface, Stringable
+final class P_22A extends AbstractValueObject implements ValueAwareInterface, Stringable, OriginalInterface
 {
     public readonly DateTimeInterface $value;
 
@@ -34,6 +35,11 @@ final class P_22A extends AbstractValueObject implements ValueAwareInterface, St
     public function __toString(): string
     {
         return $this->value->format('Y-m-d');
+    }
+
+    public function toOriginal(): string
+    {
+        return (string) $this;
     }
 
     public static function from(string $value): self

--- a/src/ValueObjects/Requests/Sessions/P_6.php
+++ b/src/ValueObjects/Requests/Sessions/P_6.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace N1ebieski\KSEFClient\ValueObjects\Requests\Sessions;
 
 use DateTimeInterface;
+use N1ebieski\KSEFClient\Contracts\OriginalInterface;
 use DateTimeImmutable;
 use N1ebieski\KSEFClient\Contracts\ValueAwareInterface;
 use N1ebieski\KSEFClient\Support\AbstractValueObject;
 use Stringable;
 
-final class P_6 extends AbstractValueObject implements ValueAwareInterface, Stringable
+final class P_6 extends AbstractValueObject implements ValueAwareInterface, Stringable, OriginalInterface
 {
     public readonly DateTimeInterface $value;
 
@@ -26,6 +27,11 @@ final class P_6 extends AbstractValueObject implements ValueAwareInterface, Stri
     public function __toString(): string
     {
         return $this->value->format('Y-m-d');
+    }
+
+    public function toOriginal(): string
+    {
+        return (string) $this;
     }
 
     public static function from(string $value): self

--- a/src/ValueObjects/Requests/Sessions/P_6A.php
+++ b/src/ValueObjects/Requests/Sessions/P_6A.php
@@ -6,6 +6,7 @@ namespace N1ebieski\KSEFClient\ValueObjects\Requests\Sessions;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use N1ebieski\KSEFClient\Contracts\OriginalInterface;
 use N1ebieski\KSEFClient\Contracts\ValueAwareInterface;
 use N1ebieski\KSEFClient\Support\AbstractValueObject;
 use N1ebieski\KSEFClient\Validator\Rules\Date\AfterRule;
@@ -13,7 +14,7 @@ use N1ebieski\KSEFClient\Validator\Rules\Date\BeforeRule;
 use N1ebieski\KSEFClient\Validator\Validator;
 use Stringable;
 
-final class P_6A extends AbstractValueObject implements ValueAwareInterface, Stringable
+final class P_6A extends AbstractValueObject implements ValueAwareInterface, Stringable, OriginalInterface
 {
     public readonly DateTimeInterface $value;
 
@@ -34,6 +35,11 @@ final class P_6A extends AbstractValueObject implements ValueAwareInterface, Str
     public function __toString(): string
     {
         return $this->value->format('Y-m-d');
+    }
+
+    public function toOriginal(): string
+    {
+        return (string) $this;
     }
 
     public static function from(string $value): self

--- a/src/ValueObjects/Requests/Sessions/P_6Z.php
+++ b/src/ValueObjects/Requests/Sessions/P_6Z.php
@@ -6,6 +6,7 @@ namespace N1ebieski\KSEFClient\ValueObjects\Requests\Sessions;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use N1ebieski\KSEFClient\Contracts\OriginalInterface;
 use N1ebieski\KSEFClient\Contracts\ValueAwareInterface;
 use N1ebieski\KSEFClient\Support\AbstractValueObject;
 use N1ebieski\KSEFClient\Validator\Rules\Date\AfterRule;
@@ -13,7 +14,7 @@ use N1ebieski\KSEFClient\Validator\Rules\Date\BeforeRule;
 use N1ebieski\KSEFClient\Validator\Validator;
 use Stringable;
 
-final class P_6Z extends AbstractValueObject implements ValueAwareInterface, Stringable
+final class P_6Z extends AbstractValueObject implements ValueAwareInterface, Stringable, OriginalInterface
 {
     public readonly DateTimeInterface $value;
 
@@ -34,6 +35,11 @@ final class P_6Z extends AbstractValueObject implements ValueAwareInterface, Str
     public function __toString(): string
     {
         return $this->value->format('Y-m-d');
+    }
+
+    public function toOriginal(): string
+    {
+        return (string) $this;
     }
 
     public static function from(string $value): self

--- a/src/ValueObjects/Requests/Sessions/P_6_Do.php
+++ b/src/ValueObjects/Requests/Sessions/P_6_Do.php
@@ -6,6 +6,7 @@ namespace N1ebieski\KSEFClient\ValueObjects\Requests\Sessions;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use N1ebieski\KSEFClient\Contracts\OriginalInterface;
 use N1ebieski\KSEFClient\Contracts\ValueAwareInterface;
 use N1ebieski\KSEFClient\Support\AbstractValueObject;
 use N1ebieski\KSEFClient\Validator\Rules\Date\AfterRule;
@@ -13,7 +14,7 @@ use N1ebieski\KSEFClient\Validator\Rules\Date\BeforeRule;
 use N1ebieski\KSEFClient\Validator\Validator;
 use Stringable;
 
-final class P_6_Do extends AbstractValueObject implements ValueAwareInterface, Stringable
+final class P_6_Do extends AbstractValueObject implements ValueAwareInterface, Stringable, OriginalInterface
 {
     public readonly DateTimeInterface $value;
 
@@ -34,6 +35,11 @@ final class P_6_Do extends AbstractValueObject implements ValueAwareInterface, S
     public function __toString(): string
     {
         return $this->value->format('Y-m-d');
+    }
+
+    public function toOriginal(): string
+    {
+        return (string) $this;
     }
 
     public static function from(string $value): self

--- a/src/ValueObjects/Requests/Sessions/P_6_Od.php
+++ b/src/ValueObjects/Requests/Sessions/P_6_Od.php
@@ -6,6 +6,7 @@ namespace N1ebieski\KSEFClient\ValueObjects\Requests\Sessions;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use N1ebieski\KSEFClient\Contracts\OriginalInterface;
 use N1ebieski\KSEFClient\Contracts\ValueAwareInterface;
 use N1ebieski\KSEFClient\Support\AbstractValueObject;
 use N1ebieski\KSEFClient\Validator\Rules\Date\AfterRule;
@@ -13,7 +14,7 @@ use N1ebieski\KSEFClient\Validator\Rules\Date\BeforeRule;
 use N1ebieski\KSEFClient\Validator\Validator;
 use Stringable;
 
-final class P_6_Od extends AbstractValueObject implements ValueAwareInterface, Stringable
+final class P_6_Od extends AbstractValueObject implements ValueAwareInterface, Stringable, OriginalInterface
 {
     public readonly DateTimeInterface $value;
 
@@ -34,6 +35,11 @@ final class P_6_Od extends AbstractValueObject implements ValueAwareInterface, S
     public function __toString(): string
     {
         return $this->value->format('Y-m-d');
+    }
+
+    public function toOriginal(): string
+    {
+        return (string) $this;
     }
 
     public static function from(string $value): self

--- a/src/ValueObjects/Requests/Sessions/Termin.php
+++ b/src/ValueObjects/Requests/Sessions/Termin.php
@@ -6,6 +6,7 @@ namespace N1ebieski\KSEFClient\ValueObjects\Requests\Sessions;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use N1ebieski\KSEFClient\Contracts\OriginalInterface;
 use N1ebieski\KSEFClient\Contracts\ValueAwareInterface;
 use N1ebieski\KSEFClient\Support\AbstractValueObject;
 use N1ebieski\KSEFClient\Validator\Rules\Date\AfterRule;
@@ -13,7 +14,7 @@ use N1ebieski\KSEFClient\Validator\Rules\Date\BeforeRule;
 use N1ebieski\KSEFClient\Validator\Validator;
 use Stringable;
 
-final class Termin extends AbstractValueObject implements ValueAwareInterface, Stringable
+final class Termin extends AbstractValueObject implements ValueAwareInterface, Stringable, OriginalInterface
 {
     public readonly DateTimeInterface $value;
 
@@ -34,6 +35,11 @@ final class Termin extends AbstractValueObject implements ValueAwareInterface, S
     public function __toString(): string
     {
         return $this->value->format('Y-m-d');
+    }
+
+    public function toOriginal(): string
+    {
+        return (string) $this;
     }
 
     public static function from(string $value): self

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -12,6 +12,9 @@ use N1ebieski\KSEFClient\Testing\Fixtures\Requests\Testdata\RateLimits\Limits\Li
 use N1ebieski\KSEFClient\Tests\Feature\AbstractTestCase as FeatureAbstractTestCase;
 use N1ebieski\KSEFClient\Tests\Unit\AbstractTestCase as UnitAbstractTestCase;
 use N1ebieski\KSEFClient\ValueObjects\Mode;
+use Pest\Expectation;
+
+/** @var Expectation<mixed> $this */
 
 /*
 |--------------------------------------------------------------------------
@@ -103,12 +106,21 @@ expect()->extend('toBeExceptionFixture', function (array $data): void {
     /** @var array{exception: array{exceptionCode: string, exceptionDescription: string, exceptionDetailList: array<array{exceptionCode: string, exceptionDescription: string}>}} $data */
     $firstException = $data['exception']['exceptionDetailList'][0];
 
-    //@phpstan-ignore-next-line
     expect($this->value)->toThrow(new BadRequestException(
         message: "{$firstException['exceptionCode']} {$firstException['exceptionDescription']}",
         code: 400,
         context: (object) $data
     ));
+});
+
+expect()->extend('toBeArrayWithoutObjectsRecursively', function (): void {
+    /** @var Expectation<mixed> $this */
+    expect($this->value)->toBeArray();
+
+    /** @var array<string, mixed> $value */
+    $value = $this->value;
+
+    toBeArrayWithoutObjectsRecursively($value);
 });
 
 /*
@@ -121,6 +133,25 @@ expect()->extend('toBeExceptionFixture', function (array $data): void {
 | global functions to help you to reduce the number of lines of code in your test files.
 |
 */
+
+/**
+ * @param array<string, mixed> $values
+ */
+function toBeArrayWithoutObjectsRecursively(array $values, string $path = 'root'): void
+{
+    foreach ($values as $key => $value) {
+        $currentPath = "{$path}.{$key}";
+
+        if (is_array($value)) {
+            /** @var array<string, mixed> $value */
+            toBeArrayWithoutObjectsRecursively($value, $currentPath);
+
+            continue;
+        }
+
+        expect($value)->not->toBeObject("Found object at {$currentPath}");
+    }
+}
 
 /**
  * @param array<string, mixed> $data

--- a/tests/Unit/DTOs/Requests/Sessions/FakturaRR/FakturaTest.php
+++ b/tests/Unit/DTOs/Requests/Sessions/FakturaRR/FakturaTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use N1ebieski\KSEFClient\DTOs\Requests\Sessions\FakturaRR\Faktura;
+use N1ebieski\KSEFClient\Testing\Fixtures\DTOs\Requests\Sessions\FakturaRR\FakturaSprzedazyTowaruRolniczegoFixture;
+
+test('toArray does not contain objects', function (): void {
+    $fixture = new FakturaSprzedazyTowaruRolniczegoFixture();
+
+    $faktura = Faktura::from($fixture->data);
+    $array = $faktura->toArray();
+
+    expect($array)->toBeArrayWithoutObjectsRecursively();
+});

--- a/tests/Unit/DTOs/Requests/Sessions/FakturaTest.php
+++ b/tests/Unit/DTOs/Requests/Sessions/FakturaTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use N1ebieski\KSEFClient\DTOs\Requests\Sessions\Faktura;
+use N1ebieski\KSEFClient\Testing\Fixtures\DTOs\Requests\Sessions\FakturaSprzedazyTowaruFixture;
+
+test('toArray does not contain objects', function (): void {
+    $fixture = new FakturaSprzedazyTowaruFixture();
+
+    $faktura = Faktura::from($fixture->data);
+    $array = $faktura->toArray();
+
+    expect($array)->toBeArrayWithoutObjectsRecursively();
+});


### PR DESCRIPTION
Addressed the issue with DateTimeImmutable fields not being normalized when converting a Faktura object to an array. Updated the version to 1.2.1 and added tests to ensure that the `toArray()` method does not include object instances, allowing for proper loading of Faktura from an array later.

Fixes #200