### PR TITLE
Make DateTime objects accept timezone-aware strings

### DIFF
--- a/src/ValueObjects/Requests/Invoices/DateRangeFrom.php
+++ b/src/ValueObjects/Requests/Invoices/DateRangeFrom.php
@@ -22,6 +22,7 @@ final class DateRangeFrom extends AbstractValueObject implements ValueAwareInter
     {
         if ($value instanceof DateTimeInterface === false) {
             $value = new DateTimeImmutable($value, new DateTimeZone('UTC'));
+            $value = $value->setTimezone(new DateTimeZone('UTC'));
         }
 
         Validator::validate($value, [

--- a/src/ValueObjects/Requests/Invoices/DateRangeTo.php
+++ b/src/ValueObjects/Requests/Invoices/DateRangeTo.php
@@ -22,6 +22,7 @@ final class DateRangeTo extends AbstractValueObject implements ValueAwareInterfa
     {
         if ($value instanceof DateTimeInterface === false) {
             $value = new DateTimeImmutable($value, new DateTimeZone('UTC'));
+            $value = $value->setTimezone(new DateTimeZone('UTC'));
         }
 
         Validator::validate($value, [

--- a/src/ValueObjects/Requests/Sessions/DataGodzRozpTransportu.php
+++ b/src/ValueObjects/Requests/Sessions/DataGodzRozpTransportu.php
@@ -24,6 +24,7 @@ final class DataGodzRozpTransportu extends AbstractValueObject implements ValueA
     {
         if ($value instanceof DateTimeInterface === false) {
             $value = new DateTimeImmutable($value, new DateTimeZone('UTC'));
+            $value = $value->setTimezone(new DateTimeZone('UTC'));
         }
 
         Validator::validate($value, [

--- a/src/ValueObjects/Requests/Sessions/DataGodzZakTransportu.php
+++ b/src/ValueObjects/Requests/Sessions/DataGodzZakTransportu.php
@@ -24,6 +24,7 @@ final class DataGodzZakTransportu extends AbstractValueObject implements ValueAw
     {
         if ($value instanceof DateTimeInterface === false) {
             $value = new DateTimeImmutable($value, new DateTimeZone('UTC'));
+            $value = $value->setTimezone(new DateTimeZone('UTC'));
         }
 
         Validator::validate($value, [

--- a/src/ValueObjects/Requests/Sessions/DataWytworzeniaFa.php
+++ b/src/ValueObjects/Requests/Sessions/DataWytworzeniaFa.php
@@ -22,6 +22,7 @@ final class DataWytworzeniaFa extends AbstractValueObject implements ValueAwareI
     {
         if ($value instanceof DateTimeInterface === false) {
             $value = new DateTimeImmutable($value, new DateTimeZone('UTC'));
+            $value = $value->setTimezone(new DateTimeZone('UTC'));
         }
 
         Validator::validate($value, [

--- a/tests/Unit/ValueObjects/DateTimeTest.php
+++ b/tests/Unit/ValueObjects/DateTimeTest.php
@@ -44,3 +44,13 @@ test('ensure that class throws timezone exception for datetime which is not in U
 
     new $classname($datetime);
 })->with('classnameProvider')->throws(RuleValidationException::class, 'Date must be in timezone: UTC, Z.');
+
+test('ensure that class normalizes an explicitly offset string to UTC', function (string $classname): void {
+    /** @var ValueAwareInterface $class */
+    $class = new $classname('2026-08-07T16:43:45.9754372+02:00');
+
+    /** @var DateTimeInterface $classDatetime */
+    $classDatetime = $class->value;
+    expect($classDatetime->getTimezone()->getName())->toBe('UTC');
+    expect($classDatetime->format('Y-m-d\\TH:i:s.u\\Z'))->toBe('2026-08-07T14:43:45.975437Z');
+})->with('classnameProvider');


### PR DESCRIPTION
Hi!
I hit a problem when exporting invoices from KSeF.

I got in response XML
```xml
<DataWytworzeniaFA>2026-08-07T16:43:45.9754372+02:00</DataWytworzeniaFA>
```

And the construct failed on `Validator::validate`.

The schemat.xsd mark field as etd:TDataCzas and inside it is xsd:dateTime so received string is valid for XML.

This affects albo:

- DataGodzRozpTransportu
- DataGodzZakTransportu
- DateRangeFrom
- DateRangeTo

The fix is to convert string values to UTC immediately after parsing them, before running the existing timezone
validation. That way the timestamp above becomes the equivalent UTC time:

`2026-08-07T14:43:45.975437Z`

Existing validation for DateTimeInterface inputs stays the same, so passing a non-UTC DateTime object directly
remains invalid.
