### PR TITLE
XML deserialization for DodatkowyOpis Fix

### DIFF
--- a/src/DTOs/Requests/Sessions/DodatkowyOpis.php
+++ b/src/DTOs/Requests/Sessions/DodatkowyOpis.php
@@ -58,6 +58,10 @@ final class DodatkowyOpis extends AbstractDTO implements DomSerializableInterfac
 
     public static function normalizeXmlArray(array $data): array
     {
+        if (isset($data['NrWiersza'])) {
+            $data['NrWiersza'] = (int) $data['NrWiersza']; //@phpstan-ignore-line cast.int
+        }
+
         return Arr::only($data, ['Klucz', 'Wartosc', 'NrWiersza']);
     }
 }

--- a/tests/Unit/DTOs/Requests/Sessions/FakturaFromXmlEnsureListTest.php
+++ b/tests/Unit/DTOs/Requests/Sessions/FakturaFromXmlEnsureListTest.php
@@ -6,6 +6,7 @@ use N1ebieski\KSEFClient\DTOs\Requests\Sessions\Faktura;
 use N1ebieski\KSEFClient\Support\Optional;
 use N1ebieski\KSEFClient\Testing\Fixtures\DTOs\Requests\Sessions\FakturaSprzedazyTowaruFixture;
 use N1ebieski\KSEFClient\Testing\Fixtures\DTOs\Requests\Sessions\FakturaZaliczkowaZDodatkowymNabywcaFixture;
+use N1ebieski\KSEFClient\ValueObjects\Requests\Sessions\NrWiersza;
 
 test('fromXml handles single FaWiersz element (not wrapped in array by SimpleXML)', function (): void {
     $fixture = new FakturaSprzedazyTowaruFixture();
@@ -115,4 +116,84 @@ test('fromXml handles absent optional array fields as Optional', function (): vo
     $deserialized = Faktura::fromXml($faktura->toXml());
 
     expect($deserialized->podmiot3)->toBeInstanceOf(Optional::class);
+});
+
+test('fromXml handles single DodatkowyOpis element with NrWiersza', function (): void {
+    $fixture = new FakturaSprzedazyTowaruFixture();
+    $fixture->data['fa']['dodatkowyOpis'] = [[
+        'nrWiersza' => 1,
+        'klucz' => 'Pierwszy klucz',
+        'wartosc' => 'Pierwsza wartość',
+    ]];
+
+    $faktura = Faktura::from($fixture->data);
+
+    $deserialized = Faktura::fromXml($faktura->toXml());
+
+    $dodatkowyOpis = $deserialized->fa->dodatkowyOpis;
+    expect($dodatkowyOpis)->not->toBeInstanceOf(Optional::class);
+    expect($dodatkowyOpis)->toHaveCount(1);
+
+    $nrWiersza = $dodatkowyOpis[0]->nrWiersza;
+    expect($nrWiersza)->toBeInstanceOf(NrWiersza::class);
+    if ($nrWiersza instanceof NrWiersza) {
+        expect($nrWiersza->value)->toBe(1);
+    }
+
+    //@phpstan-ignore-next-line cast.string
+    expect((string) $dodatkowyOpis[0]->klucz)->toBe($fixture->data['fa']['dodatkowyOpis'][0]['klucz']);
+    //@phpstan-ignore-next-line cast.string
+    expect((string) $dodatkowyOpis[0]->wartosc)->toBe($fixture->data['fa']['dodatkowyOpis'][0]['wartosc']);
+});
+
+test('fromXml handles multiple DodatkowyOpis elements with NrWiersza', function (): void {
+    $fixture = new FakturaSprzedazyTowaruFixture();
+    $fixture->data['fa']['dodatkowyOpis'] = [
+        [
+            'nrWiersza' => 1,
+            'klucz' => 'Pierwszy klucz',
+            'wartosc' => 'Pierwsza wartość',
+        ],
+        [
+            'nrWiersza' => 2,
+            'klucz' => 'Drugi klucz',
+            'wartosc' => 'Druga wartość',
+        ],
+    ];
+
+    $faktura = Faktura::from($fixture->data);
+
+    $deserialized = Faktura::fromXml($faktura->toXml());
+
+    $dodatkowyOpis = $deserialized->fa->dodatkowyOpis;
+    expect($dodatkowyOpis)->not->toBeInstanceOf(Optional::class);
+    expect($dodatkowyOpis)->toHaveCount(2);
+
+    $nrWiersza = $dodatkowyOpis[0]->nrWiersza;
+    expect($nrWiersza)->toBeInstanceOf(NrWiersza::class);
+    if ($nrWiersza instanceof NrWiersza) {
+        expect($nrWiersza->value)->toBe(1);
+    }
+
+    $nrWiersza1 = $dodatkowyOpis[1]->nrWiersza;
+    expect($nrWiersza1)->toBeInstanceOf(NrWiersza::class);
+    if ($nrWiersza1 instanceof NrWiersza) {
+        expect($nrWiersza1->value)->toBe(2);
+    }
+});
+
+test('fromXml preserves an absent DodatkowyOpis NrWiersza as Optional', function (): void {
+    $fixture = new FakturaSprzedazyTowaruFixture();
+    $fixture->data['fa']['dodatkowyOpis'] = [[
+        'klucz' => 'Klucz bez numeru wiersza',
+        'wartosc' => 'Wartość bez numeru wiersza',
+    ]];
+
+    $faktura = Faktura::from($fixture->data);
+
+    $deserialized = Faktura::fromXml($faktura->toXml());
+
+    expect($deserialized->fa->dodatkowyOpis)->not->toBeInstanceOf(Optional::class);
+    expect($deserialized->fa->dodatkowyOpis)->toHaveCount(1);
+    expect($deserialized->fa->dodatkowyOpis[0]->nrWiersza)->toBeInstanceOf(Optional::class);
 });

--- a/tests/Unit/DTOs/Requests/Sessions/FakturaFromXmlEnsureListTest.php
+++ b/tests/Unit/DTOs/Requests/Sessions/FakturaFromXmlEnsureListTest.php
@@ -120,45 +120,12 @@ test('fromXml handles absent optional array fields as Optional', function (): vo
 
 test('fromXml handles single DodatkowyOpis element with NrWiersza', function (): void {
     $fixture = new FakturaSprzedazyTowaruFixture();
-    $fixture->data['fa']['dodatkowyOpis'] = [[
-        'nrWiersza' => 1,
-        'klucz' => 'Pierwszy klucz',
-        'wartosc' => 'Pierwsza wartość',
-    ]];
-
-    $faktura = Faktura::from($fixture->data);
-
-    $deserialized = Faktura::fromXml($faktura->toXml());
-
-    $dodatkowyOpis = $deserialized->fa->dodatkowyOpis;
-    expect($dodatkowyOpis)->not->toBeInstanceOf(Optional::class);
-    expect($dodatkowyOpis)->toHaveCount(1);
-
-    $nrWiersza = $dodatkowyOpis[0]->nrWiersza;
-    expect($nrWiersza)->toBeInstanceOf(NrWiersza::class);
-    if ($nrWiersza instanceof NrWiersza) {
-        expect($nrWiersza->value)->toBe(1);
-    }
-
-    //@phpstan-ignore-next-line cast.string
-    expect((string) $dodatkowyOpis[0]->klucz)->toBe($fixture->data['fa']['dodatkowyOpis'][0]['klucz']);
-    //@phpstan-ignore-next-line cast.string
-    expect((string) $dodatkowyOpis[0]->wartosc)->toBe($fixture->data['fa']['dodatkowyOpis'][0]['wartosc']);
-});
-
-test('fromXml handles multiple DodatkowyOpis elements with NrWiersza', function (): void {
-    $fixture = new FakturaSprzedazyTowaruFixture();
     $fixture->data['fa']['dodatkowyOpis'] = [
         [
             'nrWiersza' => 1,
-            'klucz' => 'Pierwszy klucz',
-            'wartosc' => 'Pierwsza wartość',
-        ],
-        [
-            'nrWiersza' => 2,
-            'klucz' => 'Drugi klucz',
-            'wartosc' => 'Druga wartość',
-        ],
+            'klucz' => 'First key',
+            'wartosc' => 'First value',
+        ]
     ];
 
     $faktura = Faktura::from($fixture->data);
@@ -166,34 +133,28 @@ test('fromXml handles multiple DodatkowyOpis elements with NrWiersza', function 
     $deserialized = Faktura::fromXml($faktura->toXml());
 
     $dodatkowyOpis = $deserialized->fa->dodatkowyOpis;
-    expect($dodatkowyOpis)->not->toBeInstanceOf(Optional::class);
-    expect($dodatkowyOpis)->toHaveCount(2);
 
-    $nrWiersza = $dodatkowyOpis[0]->nrWiersza;
-    expect($nrWiersza)->toBeInstanceOf(NrWiersza::class);
-    if ($nrWiersza instanceof NrWiersza) {
-        expect($nrWiersza->value)->toBe(1);
-    }
+    expect($dodatkowyOpis[0]->nrWiersza)->toBeInstanceOf(NrWiersza::class);
 
-    $nrWiersza1 = $dodatkowyOpis[1]->nrWiersza;
-    expect($nrWiersza1)->toBeInstanceOf(NrWiersza::class);
-    if ($nrWiersza1 instanceof NrWiersza) {
-        expect($nrWiersza1->value)->toBe(2);
-    }
+    expect($dodatkowyOpis[0]->toArray())->toBeArray()->toEqual($fixture->data['fa']['dodatkowyOpis'][0]);
 });
 
 test('fromXml preserves an absent DodatkowyOpis NrWiersza as Optional', function (): void {
     $fixture = new FakturaSprzedazyTowaruFixture();
-    $fixture->data['fa']['dodatkowyOpis'] = [[
-        'klucz' => 'Klucz bez numeru wiersza',
-        'wartosc' => 'Wartość bez numeru wiersza',
-    ]];
+    $fixture->data['fa']['dodatkowyOpis'] = [
+        [
+            'klucz' => 'First key without NrWiersza',
+            'wartosc' => 'First value without NrWiersza',
+        ]
+    ];
 
     $faktura = Faktura::from($fixture->data);
 
     $deserialized = Faktura::fromXml($faktura->toXml());
 
-    expect($deserialized->fa->dodatkowyOpis)->not->toBeInstanceOf(Optional::class);
-    expect($deserialized->fa->dodatkowyOpis)->toHaveCount(1);
-    expect($deserialized->fa->dodatkowyOpis[0]->nrWiersza)->toBeInstanceOf(Optional::class);
+    $dodatkowyOpis = $deserialized->fa->dodatkowyOpis;
+
+    expect($dodatkowyOpis[0]->nrWiersza)->toBeInstanceOf(Optional::class);
+
+    expect($dodatkowyOpis[0]->toArray())->toBeArray()->toEqual($fixture->data['fa']['dodatkowyOpis'][0]);
 });


### PR DESCRIPTION
Hi!
It's me again exporting invoices :smile: 

I got in response XML
```xml
<DodatkowyOpis>
  <NrWiersza>1</NrWiersza>
  <Klucz>Opis pozycji</Klucz>
  <Wartosc>Wartość</Wartosc>
</DodatkowyOpis>
```
and when I call Faktura::fromXml error occurs
```php
Fatal error: Uncaught CuyZ\Valinor\Mapper\TypeTreeMapperError: Could not map type `N1ebieski\KSEFClient\DTOs\Requests\Sessions\Faktura`. An error occurred at path fa.dodatkowyOpis.0: Unexpected key `0`. in /var/www/html/vendor/cuyz/valinor/src/Mapper/TypeTreeMapper.php:38
```

The problem is in DodatkowyOpis normalizer that is not casting NrWiersza to integer.

The fix add casting to int when NrWiersza is present and adding tests covering those situations